### PR TITLE
oncokb annotator link

### DIFF
--- a/actionable_resistant_mutations/README.md
+++ b/actionable_resistant_mutations/README.md
@@ -1,0 +1,8 @@
+# Genie Analysis: Actionable and Resistant Mutations
+
+Authors: Michelle Green and  Jonathan Bell, DUKE
+
+This analysis component used the OncoKB annotator from MSK:
+
+https://github.com/oncokb/oncokb-annotator/blob/master/README.md
+


### PR DESCRIPTION
Added OncoKB annotator link at the request of Michelle Green for the "Actionable and resistant mutations" analysis component